### PR TITLE
Remove unused API property Collection.footprint

### DIFF
--- a/app/catalog/types.ts
+++ b/app/catalog/types.ts
@@ -34,7 +34,6 @@ export type Collection = {
   name          : string
   metadata      : Metadata
   productsSchema: any
-  footprint     : Footprint
 }
 
 export type Footprint = {


### PR DESCRIPTION
An entire collection's footprint is returned by the API, but it is not
used in the application at the moment.

Furthermore, the footprint is actually currently wrong for the
Scottish LIDAR Phase III and IV data, in the sense that it does not
cover all the available data -- it ends too far north and misses a lot
of data in the south. For this reason, the application probably
shouldn't rely on the collection footprint in the future.